### PR TITLE
WIP: Ignore invalid TPL

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -61,7 +61,7 @@ CoreRaiseTpl (
   OldTpl = gEfiCurrentTpl;
   if (OldTpl > NewTpl) {
     DEBUG ((EFI_D_ERROR, "FATAL ERROR - RaiseTpl with OldTpl(0x%x) > NewTpl(0x%x)\n", OldTpl, NewTpl));
-    ASSERT (FALSE);
+    //ASSERT (FALSE);
   }
   ASSERT (VALID_TPL (NewTpl));
 
@@ -102,7 +102,7 @@ CoreRestoreTpl (
   OldTpl = gEfiCurrentTpl;
   if (NewTpl > OldTpl) {
     DEBUG ((EFI_D_ERROR, "FATAL ERROR - RestoreTpl with NewTpl(0x%x) > OldTpl(0x%x)\n", NewTpl, OldTpl));
-    ASSERT (FALSE);
+    //ASSERT (FALSE);
   }
   ASSERT (VALID_TPL (NewTpl));
 


### PR DESCRIPTION
While enumerating PCIe devices on QEMU Virt, the driver tries to set invalid TPL
values.

TODO: Just a workaround. I have no idea what the issue is.

Cc: Abner Chang <abner.chang@hpe.com>
Cc: Sunil V L <sunilvl@ventanamicro.com>
Signed-off-by: Daniel Schaefer <daniel.schaefer@hpe.com>